### PR TITLE
When updating an existing content type, the FieldLinks collection was…

### DIFF
--- a/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -146,6 +146,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.ExecuteQueryRetry();
             }
             // Delta handling
+            existingContentType.EnsureProperty(c=>c.FieldLinks);
             List<Guid> targetIds = existingContentType.FieldLinks.AsEnumerable().Select(c1 => c1.Id).ToList();
             List<Guid> sourceIds = templateContentType.FieldRefs.Select(c1 => c1.Id).ToList();
 


### PR DESCRIPTION
… sometimes not initialized causing runtime exceptions. Adding code to ensure the FieldLinks collection always is initialized